### PR TITLE
Fix `balancer.view_trades` Abstraction

### DIFF
--- a/models/balancer/arbitrum/balancer_v2_arbitrum_trades.sql
+++ b/models/balancer/arbitrum/balancer_v2_arbitrum_trades.sql
@@ -33,9 +33,9 @@ WITH dexs AS (
     LEFT JOIN {{ ref('balancer_v2_arbitrum_pools_fees') }} pools_fees
         ON pools_fees.contract_address = SUBSTRING(vault_swap.poolId, 0, 42)
         AND vault_swap.evt_block_time = (
-            SELECT MAX(block_time)
+            SELECT MAX(evt_block_time)
             FROM balancer_v2.view_pools_fees
-            WHERE block_time <= vault_swap.evt_block_time
+            WHERE evt_block_time <= vault_swap.evt_block_time
             AND contract_address = SUBSTRING(vault_swap.`poolId` from 0 for 21)
         )
     WHERE

--- a/models/balancer/arbitrum/balancer_v2_arbitrum_trades.sql
+++ b/models/balancer/arbitrum/balancer_v2_arbitrum_trades.sql
@@ -13,103 +13,126 @@
     )
 }}
 
-{% set project_start_date = '2021-04-20' %}
+{% set project_start_date = '2021-08-26' %}
 
-WITH dexs AS (
+WITH swap_fees AS (
     SELECT
-        vault_swap.evt_block_time AS block_time,
-        '' AS taker,
-        '' AS maker,
-        vault_swap.amountOut AS token_bought_amount_raw,
-        vault_swap.amountIn AS token_sold_amount_raw,
-        CAST(NULL as double) AS amount_usd,
-        vault_swap.tokenOut AS token_bought_address,
-        vault_swap.tokenIn AS token_sold_address,
-        vault_swap.poolId AS project_contract_address,
-        vault_swap.evt_tx_hash AS tx_hash,
-        '' AS trace_address,
-        vault_swap.evt_index
-    FROM {{ source('balancer_v2_arbitrum', 'Vault_evt_Swap') }} vault_swap
-    LEFT JOIN {{ ref('balancer_v2_arbitrum_pools_fees') }} pools_fees
-        ON pools_fees.contract_address = SUBSTRING(vault_swap.poolId, 0, 42)
-        AND vault_swap.evt_block_time = (
-            SELECT MAX(evt_block_time)
-            FROM balancer_v2.view_pools_fees
-            WHERE evt_block_time <= vault_swap.evt_block_time
-            AND contract_address = SUBSTRING(vault_swap.`poolId` from 0 for 21)
-        )
+        swap.evt_block_number,
+        swap.evt_tx_hash,
+        swap.evt_index,
+        SUBSTRING(swap.`poolId`, 0, 42) AS contract_address,
+        swap.evt_block_time,
+        MAX(fees.evt_block_time) AS max_fee_evt_block_time
+    FROM
+        {{ source ('balancer_v2_arbitrum', 'Vault_evt_Swap') }} swap
+        LEFT JOIN {{ ref('balancer_v2_arbitrum_pools_fees') }} fees
+            ON fees.contract_address = SUBSTRING(swap.`poolId`, 0, 42)
+            AND fees.evt_block_time <= swap.evt_block_time
+    GROUP BY 1, 2, 3, 4, 5
+),
+dexs AS (
+    SELECT
+        swap.evt_block_time AS block_time,
+        NULL AS taker,
+        NULL AS maker,
+        swap.`amountOut` AS token_bought_amount_raw,
+        swap.`amountIn` AS token_sold_amount_raw,
+        NULL AS amount_usd,
+        swap.`tokenOut` AS token_bought_address,
+        swap.`tokenIn` AS token_sold_address,
+        swap.`poolId` AS project_contract_address,
+        pools_fees.swap_fee_percentage  / POWER(10, 18) AS swap_fee,
+        swap.evt_tx_hash AS tx_hash,
+        NULL AS trace_address,
+        swap.evt_index
+    FROM
+        swap_fees
+        INNER JOIN {{ source ('balancer_v2_arbitrum', 'Vault_evt_Swap') }} swap
+            ON swap.evt_block_number = swap_fees.evt_block_number
+            AND swap.evt_tx_hash = swap_fees.evt_tx_hash
+            AND swap.evt_index = swap_fees.evt_index
+        LEFT JOIN {{ ref('balancer_v2_arbitrum_pools_fees') }}
+            ON pools_fees.contract_address = swap_fees.contract_address
+            AND pools_fees.evt_block_time = swap_fees.max_fee_evt_block_time
     WHERE
-        vault_swap.tokenIn != SUBSTRING(vault_swap.`poolId`, 0, 42)
-        AND vault_swap.tokenOut != SUBSTRING(vault_swap.`poolId`, 0, 42)
+        swap.tokenIn != swap_fees.contract_address
+        AND swap.tokenOut != swap_fees.contract_address
+        -- Incremental logic.
         {% if is_incremental() %}
-        AND vault_swap.evt_block_time >= DATE_TRUNC("day", NOW() - interval '1 week')
+        AND swap.evt_block_time >= DATE_TRUNC("day", NOW() - interval '1 week')
         {% endif %}
 )
 SELECT
     'arbitrum' AS blockchain,
     'balancer' AS project,
     '2' AS version,
-    TRY_CAST(DATE_TRUNC('DAY', dexs.block_time) AS DATE) AS block_date,
+    TRY_CAST (DATE_TRUNC('DAY', dexs.block_time) AS DATE) AS block_date,
     dexs.block_time,
     erc20a.symbol AS token_bought_symbol,
     erc20b.symbol AS token_sold_symbol,
-    CASE
-        WHEN LOWER(erc20a.symbol) > LOWER(erc20b.symbol) THEN CONCAT(erc20b.symbol, '-', erc20a.symbol)
-        ELSE CONCAT(erc20a.symbol, '-', erc20b.symbol)
+    CASE WHEN LOWER(erc20a.symbol) > LOWER(erc20b.symbol) THEN
+        CONCAT(erc20b.symbol, '-', erc20a.symbol)
+    ELSE
+        CONCAT(erc20a.symbol, '-', erc20b.symbol)
     END AS token_pair,
     dexs.token_bought_amount_raw / POWER(10, erc20a.decimals) AS token_bought_amount,
     dexs.token_sold_amount_raw / POWER(10, erc20b.decimals) AS token_sold_amount,
     dexs.token_bought_amount_raw,
     dexs.token_sold_amount_raw,
     COALESCE(
-        dexs.amount_usd
-        ,(dexs.token_bought_amount_raw / POWER(10, p_bought.decimals)) * p_bought.price
-        ,(dexs.token_sold_amount_raw / POWER(10, p_sold.decimals)) * p_sold.price
+        dexs.amount_usd,
+        dexs.token_bought_amount_raw / POWER(10, p_bought.decimals) * p_bought.price,
+        dexs.token_sold_amount_raw / POWER(10, p_sold.decimals) * p_sold.price
     ) AS amount_usd,
     dexs.token_bought_address,
     dexs.token_sold_address,
     -- Subqueries rely on this COALESCE to avoid redundant joins with the transactions table.
-    COALESCE(dexs.taker, tx.from) AS taker, 
+    COALESCE(dexs.taker, tx.from) AS taker,
     dexs.maker,
     dexs.project_contract_address,
+    dexs.swap_fee_percentage,
     dexs.tx_hash,
     tx.from AS tx_from,
     tx.to AS tx_to,
     dexs.trace_address,
     dexs.evt_index
-FROM dexs
-INNER JOIN {{ source('arbitrum', 'transactions') }} tx
-    ON tx.hash = dexs.tx_hash
-    {% if not is_incremental() %}
-    AND tx.block_time >= '{{ project_start_date }}'
-    {% endif %}
-    {% if is_incremental() %}
-    AND tx.block_time >= DATE_TRUNC("day", NOW() - interval '1 week')
-    {% endif %}
-LEFT JOIN {{ ref('tokens_erc20') }} erc20a
-    ON erc20a.contract_address = dexs.token_bought_address
-    AND erc20a.blockchain = 'arbitrum'
-LEFT JOIN {{ ref('tokens_erc20') }} erc20b
-    ON erc20b.contract_address = dexs.token_sold_address
-    AND erc20b.blockchain = 'arbitrum'
-LEFT JOIN {{ source('prices', 'usd') }} p_bought
-    ON p_bought.minute = DATE_TRUNC('minute', dexs.block_time)
-    AND p_bought.contract_address = dexs.token_bought_address
-    AND p_bought.blockchain = 'arbitrum'
-    {% if not is_incremental() %}
-    AND p_bought.minute >= '{{ project_start_date }}'
-    {% endif %}
-    {% if is_incremental() %}
-    AND p_bought.minute >= DATE_TRUNC("day", NOW() - interval '1 week')
-    {% endif %}
-LEFT JOIN {{ source('prices', 'usd') }} p_sold
-    ON p_sold.minute = DATE_TRUNC('minute', dexs.block_time)
-    AND p_sold.contract_address = dexs.token_sold_address
-    AND p_sold.blockchain = 'arbitrum'
-    {% if not is_incremental() %}
-    AND p_sold.minute >= '{{ project_start_date }}'
-    {% endif %}
-    {% if is_incremental() %}
-    AND p_sold.minute >= DATE_TRUNC("day", NOW() - interval '1 week')
-    {% endif %}
+FROM
+    dexs
+    INNER JOIN {{ source ('arbitrum', 'transactions') }} tx
+        ON tx.hash = dexs.tx_hash
+        -- Incremental logic.
+        {% if not is_incremental () %}
+        AND tx.block_time >= '{{ project_start_date }}'
+        {% endif %}
+        {% if is_incremental () %}
+        AND tx.block_time >= DATE_TRUNC("day", NOW() - interval '1 week')
+        {% endif %}
+    LEFT JOIN {{ ref ('tokens_erc20') }} erc20a
+        ON erc20a.contract_address = dexs.token_bought_address
+        AND erc20a.blockchain = 'arbitrum'
+    LEFT JOIN {{ ref ('tokens_erc20') }} erc20b
+        ON erc20b.contract_address = dexs.token_sold_address
+        AND erc20b.blockchain = 'arbitrum'
+    LEFT JOIN {{ source ('prices', 'usd') }} p_bought
+        ON p_bought.minute = DATE_TRUNC('minute', dexs.block_time)
+        AND p_bought.contract_address = dexs.token_bought_address
+        AND p_bought.blockchain = 'arbitrum'
+        -- Incremental logic.
+        {% if not is_incremental () %}
+        AND p_bought.minute >= '{{ project_start_date }}'
+        {% endif %}
+        {% if is_incremental () %}
+        AND p_bought.minute >= DATE_TRUNC("day", NOW() - interval '1 week')
+        {% endif %}
+    LEFT JOIN {{ source ('prices', 'usd') }} p_sold 
+        ON p_sold.minute = DATE_TRUNC('minute', dexs.block_time)
+        AND p_sold.contract_address = dexs.token_sold_address
+        AND p_sold.blockchain = 'arbitrum' 
+        -- Incremental logic.
+        {% if not is_incremental () %}
+        AND p_sold.minute >= '{{ project_start_date }}'
+        {% endif %}
+        {% if is_incremental () %}
+        AND p_sold.minute >= DATE_TRUNC("day", NOW() - interval '1 week')
+        {% endif %}
 ;

--- a/models/balancer/arbitrum/balancer_v2_arbitrum_trades.sql
+++ b/models/balancer/arbitrum/balancer_v2_arbitrum_trades.sql
@@ -33,17 +33,17 @@ WITH swap_fees AS (
 dexs AS (
     SELECT
         swap.evt_block_time AS block_time,
-        NULL AS taker,
-        NULL AS maker,
+        '' AS taker,
+        '' AS maker,
         swap.`amountOut` AS token_bought_amount_raw,
         swap.`amountIn` AS token_sold_amount_raw,
-        NULL AS amount_usd,
+        CAST(NULL as DOUBLE) AS amount_usd,
         swap.`tokenOut` AS token_bought_address,
         swap.`tokenIn` AS token_sold_address,
         swap.`poolId` AS project_contract_address,
         pools_fees.swap_fee_percentage  / POWER(10, 18) AS swap_fee,
         swap.evt_tx_hash AS tx_hash,
-        NULL AS trace_address,
+        '' AS trace_address,
         swap.evt_index
     FROM
         swap_fees

--- a/models/balancer/ethereum/balancer_v2_ethereum_trades.sql
+++ b/models/balancer/ethereum/balancer_v2_ethereum_trades.sql
@@ -41,7 +41,7 @@ dexs AS (
         swap.`tokenOut` AS token_bought_address,
         swap.`tokenIn` AS token_sold_address,
         swap.`poolId` AS project_contract_address,
-        pools_fees.swap_fee_percentage AS swap_fee,
+        pools_fees.swap_fee_percentage  / POWER(10, 18) AS swap_fee,
         swap.evt_tx_hash AS tx_hash,
         NULL AS trace_address,
         swap.evt_index

--- a/models/balancer/ethereum/balancer_v2_ethereum_trades.sql
+++ b/models/balancer/ethereum/balancer_v2_ethereum_trades.sql
@@ -33,9 +33,9 @@ WITH dexs AS (
     LEFT JOIN {{ ref('balancer_v2_ethereum_pools_fees') }} pools_fees
         ON pools_fees.contract_address = SUBSTRING(vault_swap.poolId, 0, 42)
         AND vault_swap.evt_block_time = (
-            SELECT MAX(block_time)
+            SELECT MAX(evt_block_time)
             FROM balancer_v2.view_pools_fees
-            WHERE block_time <= vault_swap.evt_block_time
+            WHERE evt_block_time <= vault_swap.evt_block_time
             AND contract_address = SUBSTRING(vault_swap.`poolId` from 0 for 21)
         )
     WHERE

--- a/models/balancer/ethereum/balancer_v2_ethereum_trades.sql
+++ b/models/balancer/ethereum/balancer_v2_ethereum_trades.sql
@@ -24,8 +24,8 @@ WITH swap_fees AS (
         swap.evt_block_time,
         MAX(fees.evt_block_time) AS max_fee_evt_block_time
     FROM
-        balancer_v2."Vault_evt_Swap" swap
-        LEFT JOIN balancer_v2.view_pools_fees fees
+        {{ source ('balancer_v2_ethereum', 'Vault_evt_Swap') }} swap
+        LEFT JOIN {{ ref('balancer_v2_ethereum_pools_fees') }} fees
             ON fees.contract_address = SUBSTRING(swap.`poolId`, 0, 42)
             AND fees.evt_block_time <= swap.evt_block_time
     GROUP BY 1, 2, 3, 4, 5

--- a/models/balancer/ethereum/balancer_v2_ethereum_trades.sql
+++ b/models/balancer/ethereum/balancer_v2_ethereum_trades.sql
@@ -15,101 +15,124 @@
 
 {% set project_start_date = '2021-04-20' %}
 
-WITH dexs AS (
+WITH swap_fees AS (
     SELECT
-        vault_swap.evt_block_time AS block_time,
-        '' AS taker,
-        '' AS maker,
-        vault_swap.amountOut AS token_bought_amount_raw,
-        vault_swap.amountIn AS token_sold_amount_raw,
-        CAST(NULL as double) AS amount_usd,
-        vault_swap.tokenOut AS token_bought_address,
-        vault_swap.tokenIn AS token_sold_address,
-        vault_swap.poolId AS project_contract_address,
-        vault_swap.evt_tx_hash AS tx_hash,
-        '' AS trace_address,
-        vault_swap.evt_index
-    FROM {{ source('balancer_v2_ethereum', 'Vault_evt_Swap') }} vault_swap
-    LEFT JOIN {{ ref('balancer_v2_ethereum_pools_fees') }} pools_fees
-        ON pools_fees.contract_address = SUBSTRING(vault_swap.poolId, 0, 42)
-        AND vault_swap.evt_block_time = (
-            SELECT MAX(evt_block_time)
-            FROM balancer_v2.view_pools_fees
-            WHERE evt_block_time <= vault_swap.evt_block_time
-            AND contract_address = SUBSTRING(vault_swap.`poolId` from 0 for 21)
-        )
+        swap.evt_block_number,
+        swap.evt_tx_hash,
+        swap.evt_index,
+        SUBSTRING(swap."poolId" FROM 0 FOR 21) AS contract_address,
+        swap.evt_block_time,
+        MAX(fees.evt_block_time) AS max_fee_evt_block_time
+    FROM
+        balancer_v2."Vault_evt_Swap" swap
+        LEFT JOIN balancer_v2.view_pools_fees fees
+            ON fees.contract_address = SUBSTRING(swap."poolId" FROM 0 FOR 21)
+            AND fees.evt_block_time <= swap.evt_block_time
+    GROUP BY 1, 2, 3, 4, 5
+),
+dexs AS (
+    SELECT
+        swap.evt_block_time AS block_time,
+        NULL AS taker,
+        NULL AS maker,
+        swap.amountOut AS token_bought_amount_raw,
+        swap.amountIn AS token_sold_amount_raw,
+        NULL AS amount_usd,
+        swap.tokenOut AS token_bought_address,
+        swap.tokenIn AS token_sold_address,
+        swap.poolId AS project_contract_address,
+        pools_fees.swap_fee_percentage AS swap_fee,
+        swap.evt_tx_hash AS tx_hash,
+        NULL AS trace_address,
+        swap.evt_index
+    FROM
+        swap_fees
+        INNER JOIN {{ source ('balancer_v2_ethereum', 'Vault_evt_Swap') }} swap
+            ON swap.evt_block_number = swap_fees.evt_block_number
+            AND swap.evt_tx_hash = swap_fees.evt_tx_hash
+            AND swap.evt_index = swap_fees.evt_index
+        LEFT JOIN {{ ref('balancer_v2_ethereum_pools_fees') }}
+            ON pools_fees.contract_address = swap_fees.contract_address
+            AND pools_fees.evt_block_time = swap_fees.max_fee_evt_block_time
     WHERE
-        vault_swap.tokenIn != SUBSTRING(vault_swap.`poolId`, 0, 42)
-        AND vault_swap.tokenOut != SUBSTRING(vault_swap.`poolId`, 0, 42)
+        swap.tokenIn != SUBSTRING(vault_swap. `poolId`, 0, 42)
+        AND swap.tokenOut != SUBSTRING(vault_swap. `poolId`, 0, 42)
+        -- Incremental logic.
         {% if is_incremental() %}
-        AND vault_swap.evt_block_time >= DATE_TRUNC("day", NOW() - interval '1 week')
+        AND swap.evt_block_time >= DATE_TRUNC("day", NOW() - interval '1 week')
         {% endif %}
 )
 SELECT
     'ethereum' AS blockchain,
     'balancer' AS project,
     '2' AS version,
-    TRY_CAST(DATE_TRUNC('DAY', dexs.block_time) AS DATE) AS block_date,
+    TRY_CAST (DATE_TRUNC('DAY', dexs.block_time) AS DATE) AS block_date,
     dexs.block_time,
     erc20a.symbol AS token_bought_symbol,
     erc20b.symbol AS token_sold_symbol,
-    CASE
-        WHEN LOWER(erc20a.symbol) > LOWER(erc20b.symbol) THEN CONCAT(erc20b.symbol, '-', erc20a.symbol)
-        ELSE CONCAT(erc20a.symbol, '-', erc20b.symbol)
+    CASE WHEN LOWER(erc20a.symbol) > LOWER(erc20b.symbol) THEN
+        CONCAT(erc20b.symbol, '-', erc20a.symbol)
+    ELSE
+        CONCAT(erc20a.symbol, '-', erc20b.symbol)
     END AS token_pair,
     dexs.token_bought_amount_raw / POWER(10, erc20a.decimals) AS token_bought_amount,
     dexs.token_sold_amount_raw / POWER(10, erc20b.decimals) AS token_sold_amount,
     dexs.token_bought_amount_raw,
     dexs.token_sold_amount_raw,
     COALESCE(
-        dexs.amount_usd
-        ,(dexs.token_bought_amount_raw / POWER(10, p_bought.decimals)) * p_bought.price
-        ,(dexs.token_sold_amount_raw / POWER(10, p_sold.decimals)) * p_sold.price
+        dexs.amount_usd,
+        dexs.token_bought_amount_raw / POWER(10, p_bought.decimals) * p_bought.price,
+        dexs.token_sold_amount_raw / POWER(10, p_sold.decimals) * p_sold.price
     ) AS amount_usd,
     dexs.token_bought_address,
     dexs.token_sold_address,
     -- Subqueries rely on this COALESCE to avoid redundant joins with the transactions table.
-    COALESCE(dexs.taker, tx.from) AS taker, 
+    COALESCE(dexs.taker, tx.from) AS taker,
     dexs.maker,
     dexs.project_contract_address,
+    dexs.swap_fee_percentage,
     dexs.tx_hash,
     tx.from AS tx_from,
     tx.to AS tx_to,
     dexs.trace_address,
     dexs.evt_index
-FROM dexs
-INNER JOIN {{ source('ethereum', 'transactions') }} tx
-    ON tx.hash = dexs.tx_hash
-    {% if not is_incremental() %}
-    AND tx.block_time >= '{{ project_start_date }}'
-    {% endif %}
-    {% if is_incremental() %}
-    AND tx.block_time >= DATE_TRUNC("day", NOW() - interval '1 week')
-    {% endif %}
-LEFT JOIN {{ ref('tokens_erc20') }} erc20a
-    ON erc20a.contract_address = dexs.token_bought_address
-    AND erc20a.blockchain = 'ethereum'
-LEFT JOIN {{ ref('tokens_erc20') }} erc20b
-    ON erc20b.contract_address = dexs.token_sold_address
-    AND erc20b.blockchain = 'ethereum'
-LEFT JOIN {{ source('prices', 'usd') }} p_bought
-    ON p_bought.minute = DATE_TRUNC('minute', dexs.block_time)
-    AND p_bought.contract_address = dexs.token_bought_address
-    AND p_bought.blockchain = 'ethereum'
-    {% if not is_incremental() %}
-    AND p_bought.minute >= '{{ project_start_date }}'
-    {% endif %}
-    {% if is_incremental() %}
-    AND p_bought.minute >= DATE_TRUNC("day", NOW() - interval '1 week')
-    {% endif %}
-LEFT JOIN {{ source('prices', 'usd') }} p_sold
-    ON p_sold.minute = DATE_TRUNC('minute', dexs.block_time)
-    AND p_sold.contract_address = dexs.token_sold_address
-    AND p_sold.blockchain = 'ethereum'
-    {% if not is_incremental() %}
-    AND p_sold.minute >= '{{ project_start_date }}'
-    {% endif %}
-    {% if is_incremental() %}
-    AND p_sold.minute >= DATE_TRUNC("day", NOW() - interval '1 week')
-    {% endif %}
+FROM
+    dexs
+    INNER JOIN {{ source ('ethereum', 'transactions') }} tx
+        ON tx.hash = dexs.tx_hash
+        -- Incremental logic.
+        {% if not is_incremental () %}
+        AND tx.block_time >= '{{ project_start_date }}'
+        {% endif %}
+        {% if is_incremental () %}
+        AND tx.block_time >= DATE_TRUNC("day", NOW() - interval '1 week')
+        {% endif %}
+    LEFT JOIN {{ ref ('tokens_erc20') }} erc20a
+        ON erc20a.contract_address = dexs.token_bought_address
+        AND erc20a.blockchain = 'ethereum'
+    LEFT JOIN {{ ref ('tokens_erc20') }} erc20b
+        ON erc20b.contract_address = dexs.token_sold_address
+        AND erc20b.blockchain = 'ethereum'
+    LEFT JOIN {{ source ('prices', 'usd') }} p_bought
+        ON p_bought.minute = DATE_TRUNC('minute', dexs.block_time)
+        AND p_bought.contract_address = dexs.token_bought_address
+        AND p_bought.blockchain = 'ethereum'
+        -- Incremental logic.
+        {% if not is_incremental () %}
+        AND p_bought.minute >= '{{ project_start_date }}'
+        {% endif %}
+        {% if is_incremental () %}
+        AND p_bought.minute >= DATE_TRUNC("day", NOW() - interval '1 week')
+        {% endif %}
+    LEFT JOIN {{ source ('prices', 'usd') }} p_sold 
+        ON p_sold.minute = DATE_TRUNC('minute', dexs.block_time)
+        AND p_sold.contract_address = dexs.token_sold_address
+        AND p_sold.blockchain = 'ethereum' 
+        -- Incremental logic.
+        {% if not is_incremental () %}
+        AND p_sold.minute >= '{{ project_start_date }}'
+        {% endif %}
+        {% if is_incremental () %}
+        AND p_sold.minute >= DATE_TRUNC("day", NOW() - interval '1 week')
+        {% endif %}
 ;

--- a/models/balancer/ethereum/balancer_v2_ethereum_trades.sql
+++ b/models/balancer/ethereum/balancer_v2_ethereum_trades.sql
@@ -33,17 +33,17 @@ WITH swap_fees AS (
 dexs AS (
     SELECT
         swap.evt_block_time AS block_time,
-        NULL AS taker,
-        NULL AS maker,
+        '' AS taker,
+        '' AS maker,
         swap.`amountOut` AS token_bought_amount_raw,
         swap.`amountIn` AS token_sold_amount_raw,
-        NULL AS amount_usd,
+        CAST(NULL as DOUBLE) AS amount_usd,
         swap.`tokenOut` AS token_bought_address,
         swap.`tokenIn` AS token_sold_address,
         swap.`poolId` AS project_contract_address,
         pools_fees.swap_fee_percentage  / POWER(10, 18) AS swap_fee,
         swap.evt_tx_hash AS tx_hash,
-        NULL AS trace_address,
+        '' AS trace_address,
         swap.evt_index
     FROM
         swap_fees

--- a/models/balancer/optimism/balancer_v2_optimism_trades.sql
+++ b/models/balancer/optimism/balancer_v2_optimism_trades.sql
@@ -33,9 +33,9 @@ WITH dexs AS (
     LEFT JOIN {{ ref('balancer_v2_optimism_pools_fees') }} pools_fees
         ON pools_fees.contract_address = SUBSTRING(vault_swap.poolId, 0, 42)
         AND vault_swap.evt_block_time = (
-            SELECT MAX(block_time)
+            SELECT MAX(evt_block_time)
             FROM balancer_v2.view_pools_fees
-            WHERE block_time <= vault_swap.evt_block_time
+            WHERE evt_block_time <= vault_swap.evt_block_time
             AND contract_address = SUBSTRING(vault_swap.`poolId` from 0 for 21)
         )
     WHERE

--- a/models/balancer/optimism/balancer_v2_optimism_trades.sql
+++ b/models/balancer/optimism/balancer_v2_optimism_trades.sql
@@ -13,103 +13,126 @@
     )
 }}
 
-{% set project_start_date = '2021-04-20' %}
+{% set project_start_date = '2022-05-19' %}
 
-WITH dexs AS (
+WITH swap_fees AS (
     SELECT
-        vault_swap.evt_block_time AS block_time,
-        '' AS taker,
-        '' AS maker,
-        vault_swap.amountOut AS token_bought_amount_raw,
-        vault_swap.amountIn AS token_sold_amount_raw,
-        CAST(NULL as double) AS amount_usd,
-        vault_swap.tokenOut AS token_bought_address,
-        vault_swap.tokenIn AS token_sold_address,
-        vault_swap.poolId AS project_contract_address,
-        vault_swap.evt_tx_hash AS tx_hash,
-        '' AS trace_address,
-        vault_swap.evt_index
-    FROM {{ source('balancer_v2_optimism', 'Vault_evt_Swap') }} vault_swap
-    LEFT JOIN {{ ref('balancer_v2_optimism_pools_fees') }} pools_fees
-        ON pools_fees.contract_address = SUBSTRING(vault_swap.poolId, 0, 42)
-        AND vault_swap.evt_block_time = (
-            SELECT MAX(evt_block_time)
-            FROM balancer_v2.view_pools_fees
-            WHERE evt_block_time <= vault_swap.evt_block_time
-            AND contract_address = SUBSTRING(vault_swap.`poolId` from 0 for 21)
-        )
+        swap.evt_block_number,
+        swap.evt_tx_hash,
+        swap.evt_index,
+        SUBSTRING(swap.`poolId`, 0, 42) AS contract_address,
+        swap.evt_block_time,
+        MAX(fees.evt_block_time) AS max_fee_evt_block_time
+    FROM
+        {{ source ('balancer_v2_optimism', 'Vault_evt_Swap') }} swap
+        LEFT JOIN {{ ref('balancer_v2_optimism_pools_fees') }} fees
+            ON fees.contract_address = SUBSTRING(swap.`poolId`, 0, 42)
+            AND fees.evt_block_time <= swap.evt_block_time
+    GROUP BY 1, 2, 3, 4, 5
+),
+dexs AS (
+    SELECT
+        swap.evt_block_time AS block_time,
+        NULL AS taker,
+        NULL AS maker,
+        swap.`amountOut` AS token_bought_amount_raw,
+        swap.`amountIn` AS token_sold_amount_raw,
+        NULL AS amount_usd,
+        swap.`tokenOut` AS token_bought_address,
+        swap.`tokenIn` AS token_sold_address,
+        swap.`poolId` AS project_contract_address,
+        pools_fees.swap_fee_percentage  / POWER(10, 18) AS swap_fee,
+        swap.evt_tx_hash AS tx_hash,
+        NULL AS trace_address,
+        swap.evt_index
+    FROM
+        swap_fees
+        INNER JOIN {{ source ('balancer_v2_optimism', 'Vault_evt_Swap') }} swap
+            ON swap.evt_block_number = swap_fees.evt_block_number
+            AND swap.evt_tx_hash = swap_fees.evt_tx_hash
+            AND swap.evt_index = swap_fees.evt_index
+        LEFT JOIN {{ ref('balancer_v2_optimism_pools_fees') }}
+            ON pools_fees.contract_address = swap_fees.contract_address
+            AND pools_fees.evt_block_time = swap_fees.max_fee_evt_block_time
     WHERE
-        vault_swap.tokenIn != SUBSTRING(vault_swap.`poolId`, 0, 42)
-        AND vault_swap.tokenOut != SUBSTRING(vault_swap.`poolId`, 0, 42)
+        swap.tokenIn != swap_fees.contract_address
+        AND swap.tokenOut != swap_fees.contract_address
+        -- Incremental logic.
         {% if is_incremental() %}
-        AND vault_swap.evt_block_time >= DATE_TRUNC("day", NOW() - interval '1 week')
+        AND swap.evt_block_time >= DATE_TRUNC("day", NOW() - interval '1 week')
         {% endif %}
 )
 SELECT
     'optimism' AS blockchain,
     'balancer' AS project,
     '2' AS version,
-    TRY_CAST(DATE_TRUNC('DAY', dexs.block_time) AS DATE) AS block_date,
+    TRY_CAST (DATE_TRUNC('DAY', dexs.block_time) AS DATE) AS block_date,
     dexs.block_time,
     erc20a.symbol AS token_bought_symbol,
     erc20b.symbol AS token_sold_symbol,
-    CASE
-        WHEN LOWER(erc20a.symbol) > LOWER(erc20b.symbol) THEN CONCAT(erc20b.symbol, '-', erc20a.symbol)
-        ELSE CONCAT(erc20a.symbol, '-', erc20b.symbol)
+    CASE WHEN LOWER(erc20a.symbol) > LOWER(erc20b.symbol) THEN
+        CONCAT(erc20b.symbol, '-', erc20a.symbol)
+    ELSE
+        CONCAT(erc20a.symbol, '-', erc20b.symbol)
     END AS token_pair,
     dexs.token_bought_amount_raw / POWER(10, erc20a.decimals) AS token_bought_amount,
     dexs.token_sold_amount_raw / POWER(10, erc20b.decimals) AS token_sold_amount,
     dexs.token_bought_amount_raw,
     dexs.token_sold_amount_raw,
     COALESCE(
-        dexs.amount_usd
-        ,(dexs.token_bought_amount_raw / POWER(10, p_bought.decimals)) * p_bought.price
-        ,(dexs.token_sold_amount_raw / POWER(10, p_sold.decimals)) * p_sold.price
+        dexs.amount_usd,
+        dexs.token_bought_amount_raw / POWER(10, p_bought.decimals) * p_bought.price,
+        dexs.token_sold_amount_raw / POWER(10, p_sold.decimals) * p_sold.price
     ) AS amount_usd,
     dexs.token_bought_address,
     dexs.token_sold_address,
     -- Subqueries rely on this COALESCE to avoid redundant joins with the transactions table.
-    COALESCE(dexs.taker, tx.from) AS taker, 
+    COALESCE(dexs.taker, tx.from) AS taker,
     dexs.maker,
     dexs.project_contract_address,
+    dexs.swap_fee_percentage,
     dexs.tx_hash,
     tx.from AS tx_from,
     tx.to AS tx_to,
     dexs.trace_address,
     dexs.evt_index
-FROM dexs
-INNER JOIN {{ source('optimism', 'transactions') }} tx
-    ON tx.hash = dexs.tx_hash
-    {% if not is_incremental() %}
-    AND tx.block_time >= '{{ project_start_date }}'
-    {% endif %}
-    {% if is_incremental() %}
-    AND tx.block_time >= DATE_TRUNC("day", NOW() - interval '1 week')
-    {% endif %}
-LEFT JOIN {{ ref('tokens_erc20') }} erc20a
-    ON erc20a.contract_address = dexs.token_bought_address
-    AND erc20a.blockchain = 'optimism'
-LEFT JOIN {{ ref('tokens_erc20') }} erc20b
-    ON erc20b.contract_address = dexs.token_sold_address
-    AND erc20b.blockchain = 'optimism'
-LEFT JOIN {{ source('prices', 'usd') }} p_bought
-    ON p_bought.minute = DATE_TRUNC('minute', dexs.block_time)
-    AND p_bought.contract_address = dexs.token_bought_address
-    AND p_bought.blockchain = 'optimism'
-    {% if not is_incremental() %}
-    AND p_bought.minute >= '{{ project_start_date }}'
-    {% endif %}
-    {% if is_incremental() %}
-    AND p_bought.minute >= DATE_TRUNC("day", NOW() - interval '1 week')
-    {% endif %}
-LEFT JOIN {{ source('prices', 'usd') }} p_sold
-    ON p_sold.minute = DATE_TRUNC('minute', dexs.block_time)
-    AND p_sold.contract_address = dexs.token_sold_address
-    AND p_sold.blockchain = 'optimism'
-    {% if not is_incremental() %}
-    AND p_sold.minute >= '{{ project_start_date }}'
-    {% endif %}
-    {% if is_incremental() %}
-    AND p_sold.minute >= DATE_TRUNC("day", NOW() - interval '1 week')
-    {% endif %}
+FROM
+    dexs
+    INNER JOIN {{ source ('optimism', 'transactions') }} tx
+        ON tx.hash = dexs.tx_hash
+        -- Incremental logic.
+        {% if not is_incremental () %}
+        AND tx.block_time >= '{{ project_start_date }}'
+        {% endif %}
+        {% if is_incremental () %}
+        AND tx.block_time >= DATE_TRUNC("day", NOW() - interval '1 week')
+        {% endif %}
+    LEFT JOIN {{ ref ('tokens_erc20') }} erc20a
+        ON erc20a.contract_address = dexs.token_bought_address
+        AND erc20a.blockchain = 'optimism'
+    LEFT JOIN {{ ref ('tokens_erc20') }} erc20b
+        ON erc20b.contract_address = dexs.token_sold_address
+        AND erc20b.blockchain = 'optimism'
+    LEFT JOIN {{ source ('prices', 'usd') }} p_bought
+        ON p_bought.minute = DATE_TRUNC('minute', dexs.block_time)
+        AND p_bought.contract_address = dexs.token_bought_address
+        AND p_bought.blockchain = 'optimism'
+        -- Incremental logic.
+        {% if not is_incremental () %}
+        AND p_bought.minute >= '{{ project_start_date }}'
+        {% endif %}
+        {% if is_incremental () %}
+        AND p_bought.minute >= DATE_TRUNC("day", NOW() - interval '1 week')
+        {% endif %}
+    LEFT JOIN {{ source ('prices', 'usd') }} p_sold 
+        ON p_sold.minute = DATE_TRUNC('minute', dexs.block_time)
+        AND p_sold.contract_address = dexs.token_sold_address
+        AND p_sold.blockchain = 'optimism' 
+        -- Incremental logic.
+        {% if not is_incremental () %}
+        AND p_sold.minute >= '{{ project_start_date }}'
+        {% endif %}
+        {% if is_incremental () %}
+        AND p_sold.minute >= DATE_TRUNC("day", NOW() - interval '1 week')
+        {% endif %}
 ;

--- a/models/balancer/optimism/balancer_v2_optimism_trades.sql
+++ b/models/balancer/optimism/balancer_v2_optimism_trades.sql
@@ -33,17 +33,17 @@ WITH swap_fees AS (
 dexs AS (
     SELECT
         swap.evt_block_time AS block_time,
-        NULL AS taker,
-        NULL AS maker,
+        '' AS taker,
+        '' AS maker,
         swap.`amountOut` AS token_bought_amount_raw,
         swap.`amountIn` AS token_sold_amount_raw,
-        NULL AS amount_usd,
+        CAST(NULL as DOUBLE) AS amount_usd,
         swap.`tokenOut` AS token_bought_address,
         swap.`tokenIn` AS token_sold_address,
         swap.`poolId` AS project_contract_address,
         pools_fees.swap_fee_percentage  / POWER(10, 18) AS swap_fee,
         swap.evt_tx_hash AS tx_hash,
-        NULL AS trace_address,
+        '' AS trace_address,
         swap.evt_index
     FROM
         swap_fees

--- a/models/balancer/polygon/balancer_v2_polygon_trades.sql
+++ b/models/balancer/polygon/balancer_v2_polygon_trades.sql
@@ -33,9 +33,9 @@ WITH dexs AS (
     LEFT JOIN {{ ref('balancer_v2_polygon_pools_fees') }} pools_fees
         ON pools_fees.contract_address = SUBSTRING(vault_swap.poolId, 0, 42)
         AND vault_swap.evt_block_time = (
-            SELECT MAX(block_time)
+            SELECT MAX(evt_block_time)
             FROM balancer_v2.view_pools_fees
-            WHERE block_time <= vault_swap.evt_block_time
+            WHERE evt_block_time <= vault_swap.evt_block_time
             AND contract_address = SUBSTRING(vault_swap.`poolId` from 0 for 21)
         )
     WHERE

--- a/models/balancer/polygon/balancer_v2_polygon_trades.sql
+++ b/models/balancer/polygon/balancer_v2_polygon_trades.sql
@@ -13,103 +13,126 @@
     )
 }}
 
-{% set project_start_date = '2021-04-20' %}
+{% set project_start_date = '2021-06-19' %}
 
-WITH dexs AS (
+WITH swap_fees AS (
     SELECT
-        vault_swap.evt_block_time AS block_time,
-        '' AS taker,
-        '' AS maker,
-        vault_swap.amountOut AS token_bought_amount_raw,
-        vault_swap.amountIn AS token_sold_amount_raw,
-        CAST(NULL as double) AS amount_usd,
-        vault_swap.tokenOut AS token_bought_address,
-        vault_swap.tokenIn AS token_sold_address,
-        vault_swap.poolId AS project_contract_address,
-        vault_swap.evt_tx_hash AS tx_hash,
-        '' AS trace_address,
-        vault_swap.evt_index
-    FROM {{ source('balancer_v2_polygon', 'Vault_evt_Swap') }} vault_swap
-    LEFT JOIN {{ ref('balancer_v2_polygon_pools_fees') }} pools_fees
-        ON pools_fees.contract_address = SUBSTRING(vault_swap.poolId, 0, 42)
-        AND vault_swap.evt_block_time = (
-            SELECT MAX(evt_block_time)
-            FROM balancer_v2.view_pools_fees
-            WHERE evt_block_time <= vault_swap.evt_block_time
-            AND contract_address = SUBSTRING(vault_swap.`poolId` from 0 for 21)
-        )
+        swap.evt_block_number,
+        swap.evt_tx_hash,
+        swap.evt_index,
+        SUBSTRING(swap.`poolId`, 0, 42) AS contract_address,
+        swap.evt_block_time,
+        MAX(fees.evt_block_time) AS max_fee_evt_block_time
+    FROM
+        {{ source ('balancer_v2_polygon', 'Vault_evt_Swap') }} swap
+        LEFT JOIN {{ ref('balancer_v2_polygon_pools_fees') }} fees
+            ON fees.contract_address = SUBSTRING(swap.`poolId`, 0, 42)
+            AND fees.evt_block_time <= swap.evt_block_time
+    GROUP BY 1, 2, 3, 4, 5
+),
+dexs AS (
+    SELECT
+        swap.evt_block_time AS block_time,
+        NULL AS taker,
+        NULL AS maker,
+        swap.`amountOut` AS token_bought_amount_raw,
+        swap.`amountIn` AS token_sold_amount_raw,
+        NULL AS amount_usd,
+        swap.`tokenOut` AS token_bought_address,
+        swap.`tokenIn` AS token_sold_address,
+        swap.`poolId` AS project_contract_address,
+        pools_fees.swap_fee_percentage  / POWER(10, 18) AS swap_fee,
+        swap.evt_tx_hash AS tx_hash,
+        NULL AS trace_address,
+        swap.evt_index
+    FROM
+        swap_fees
+        INNER JOIN {{ source ('balancer_v2_polygon', 'Vault_evt_Swap') }} swap
+            ON swap.evt_block_number = swap_fees.evt_block_number
+            AND swap.evt_tx_hash = swap_fees.evt_tx_hash
+            AND swap.evt_index = swap_fees.evt_index
+        LEFT JOIN {{ ref('balancer_v2_polygon_pools_fees') }}
+            ON pools_fees.contract_address = swap_fees.contract_address
+            AND pools_fees.evt_block_time = swap_fees.max_fee_evt_block_time
     WHERE
-        vault_swap.tokenIn != SUBSTRING(vault_swap.`poolId`, 0, 42)
-        AND vault_swap.tokenOut != SUBSTRING(vault_swap.`poolId`, 0, 42)
+        swap.tokenIn != swap_fees.contract_address
+        AND swap.tokenOut != swap_fees.contract_address
+        -- Incremental logic.
         {% if is_incremental() %}
-        AND vault_swap.evt_block_time >= DATE_TRUNC("day", NOW() - interval '1 week')
+        AND swap.evt_block_time >= DATE_TRUNC("day", NOW() - interval '1 week')
         {% endif %}
 )
 SELECT
     'polygon' AS blockchain,
     'balancer' AS project,
     '2' AS version,
-    TRY_CAST(DATE_TRUNC('DAY', dexs.block_time) AS DATE) AS block_date,
+    TRY_CAST (DATE_TRUNC('DAY', dexs.block_time) AS DATE) AS block_date,
     dexs.block_time,
     erc20a.symbol AS token_bought_symbol,
     erc20b.symbol AS token_sold_symbol,
-    CASE
-        WHEN LOWER(erc20a.symbol) > LOWER(erc20b.symbol) THEN CONCAT(erc20b.symbol, '-', erc20a.symbol)
-        ELSE CONCAT(erc20a.symbol, '-', erc20b.symbol)
+    CASE WHEN LOWER(erc20a.symbol) > LOWER(erc20b.symbol) THEN
+        CONCAT(erc20b.symbol, '-', erc20a.symbol)
+    ELSE
+        CONCAT(erc20a.symbol, '-', erc20b.symbol)
     END AS token_pair,
     dexs.token_bought_amount_raw / POWER(10, erc20a.decimals) AS token_bought_amount,
     dexs.token_sold_amount_raw / POWER(10, erc20b.decimals) AS token_sold_amount,
     dexs.token_bought_amount_raw,
     dexs.token_sold_amount_raw,
     COALESCE(
-        dexs.amount_usd
-        ,(dexs.token_bought_amount_raw / POWER(10, p_bought.decimals)) * p_bought.price
-        ,(dexs.token_sold_amount_raw / POWER(10, p_sold.decimals)) * p_sold.price
+        dexs.amount_usd,
+        dexs.token_bought_amount_raw / POWER(10, p_bought.decimals) * p_bought.price,
+        dexs.token_sold_amount_raw / POWER(10, p_sold.decimals) * p_sold.price
     ) AS amount_usd,
     dexs.token_bought_address,
     dexs.token_sold_address,
     -- Subqueries rely on this COALESCE to avoid redundant joins with the transactions table.
-    COALESCE(dexs.taker, tx.from) AS taker, 
+    COALESCE(dexs.taker, tx.from) AS taker,
     dexs.maker,
     dexs.project_contract_address,
+    dexs.swap_fee_percentage,
     dexs.tx_hash,
     tx.from AS tx_from,
     tx.to AS tx_to,
     dexs.trace_address,
     dexs.evt_index
-FROM dexs
-INNER JOIN {{ source('polygon', 'transactions') }} tx
-    ON tx.hash = dexs.tx_hash
-    {% if not is_incremental() %}
-    AND tx.block_time >= '{{ project_start_date }}'
-    {% endif %}
-    {% if is_incremental() %}
-    AND tx.block_time >= DATE_TRUNC("day", NOW() - interval '1 week')
-    {% endif %}
-LEFT JOIN {{ ref('tokens_erc20') }} erc20a
-    ON erc20a.contract_address = dexs.token_bought_address
-    AND erc20a.blockchain = 'polygon'
-LEFT JOIN {{ ref('tokens_erc20') }} erc20b
-    ON erc20b.contract_address = dexs.token_sold_address
-    AND erc20b.blockchain = 'polygon'
-LEFT JOIN {{ source('prices', 'usd') }} p_bought
-    ON p_bought.minute = DATE_TRUNC('minute', dexs.block_time)
-    AND p_bought.contract_address = dexs.token_bought_address
-    AND p_bought.blockchain = 'polygon'
-    {% if not is_incremental() %}
-    AND p_bought.minute >= '{{ project_start_date }}'
-    {% endif %}
-    {% if is_incremental() %}
-    AND p_bought.minute >= DATE_TRUNC("day", NOW() - interval '1 week')
-    {% endif %}
-LEFT JOIN {{ source('prices', 'usd') }} p_sold
-    ON p_sold.minute = DATE_TRUNC('minute', dexs.block_time)
-    AND p_sold.contract_address = dexs.token_sold_address
-    AND p_sold.blockchain = 'polygon'
-    {% if not is_incremental() %}
-    AND p_sold.minute >= '{{ project_start_date }}'
-    {% endif %}
-    {% if is_incremental() %}
-    AND p_sold.minute >= DATE_TRUNC("day", NOW() - interval '1 week')
-    {% endif %}
+FROM
+    dexs
+    INNER JOIN {{ source ('polygon', 'transactions') }} tx
+        ON tx.hash = dexs.tx_hash
+        -- Incremental logic.
+        {% if not is_incremental () %}
+        AND tx.block_time >= '{{ project_start_date }}'
+        {% endif %}
+        {% if is_incremental () %}
+        AND tx.block_time >= DATE_TRUNC("day", NOW() - interval '1 week')
+        {% endif %}
+    LEFT JOIN {{ ref ('tokens_erc20') }} erc20a
+        ON erc20a.contract_address = dexs.token_bought_address
+        AND erc20a.blockchain = 'polygon'
+    LEFT JOIN {{ ref ('tokens_erc20') }} erc20b
+        ON erc20b.contract_address = dexs.token_sold_address
+        AND erc20b.blockchain = 'polygon'
+    LEFT JOIN {{ source ('prices', 'usd') }} p_bought
+        ON p_bought.minute = DATE_TRUNC('minute', dexs.block_time)
+        AND p_bought.contract_address = dexs.token_bought_address
+        AND p_bought.blockchain = 'polygon'
+        -- Incremental logic.
+        {% if not is_incremental () %}
+        AND p_bought.minute >= '{{ project_start_date }}'
+        {% endif %}
+        {% if is_incremental () %}
+        AND p_bought.minute >= DATE_TRUNC("day", NOW() - interval '1 week')
+        {% endif %}
+    LEFT JOIN {{ source ('prices', 'usd') }} p_sold 
+        ON p_sold.minute = DATE_TRUNC('minute', dexs.block_time)
+        AND p_sold.contract_address = dexs.token_sold_address
+        AND p_sold.blockchain = 'polygon' 
+        -- Incremental logic.
+        {% if not is_incremental () %}
+        AND p_sold.minute >= '{{ project_start_date }}'
+        {% endif %}
+        {% if is_incremental () %}
+        AND p_sold.minute >= DATE_TRUNC("day", NOW() - interval '1 week')
+        {% endif %}
 ;

--- a/models/balancer/polygon/balancer_v2_polygon_trades.sql
+++ b/models/balancer/polygon/balancer_v2_polygon_trades.sql
@@ -33,17 +33,17 @@ WITH swap_fees AS (
 dexs AS (
     SELECT
         swap.evt_block_time AS block_time,
-        NULL AS taker,
-        NULL AS maker,
+        '' AS taker,
+        '' AS maker,
         swap.`amountOut` AS token_bought_amount_raw,
         swap.`amountIn` AS token_sold_amount_raw,
-        NULL AS amount_usd,
+        CAST(NULL as DOUBLE) AS amount_usd,
         swap.`tokenOut` AS token_bought_address,
         swap.`tokenIn` AS token_sold_address,
         swap.`poolId` AS project_contract_address,
         pools_fees.swap_fee_percentage  / POWER(10, 18) AS swap_fee,
         swap.evt_tx_hash AS tx_hash,
-        NULL AS trace_address,
+        '' AS trace_address,
         swap.evt_index
     FROM
         swap_fees


### PR DESCRIPTION
## Testing Ethereum

I tested that table counts are equal between the Dune v1 abstraction and the new Dune v2 spell.

I filtered on `block_time` and `minute` greater than or equal to `2022-04-20` to reduce the number of rows.

I modified the `view_trades` abstraction query to exclude balancer v1 dexs:

```sql
SELECT
    COUNT(*)
FROM (
    -- V2
    SELECT
        t.evt_block_time AS block_time,
        'Balancer' AS project,
        '2' AS version,
        'DEX' AS category,
        NULL::bytea AS trader_a, -- this relies on the outer query coalescing to tx."from"
        NULL::bytea AS trader_b,
        t."amountOut" AS token_a_amount_raw,
        t."amountIn" AS token_b_amount_raw,
        NULL::numeric AS usd_amount,
        t."tokenOut" AS token_a_address,
        t."tokenIn" AS token_b_address,
        t."poolId" AS exchange_contract_address,
        s."swapFeePercentage" / 1e18 AS swap_fee,
        t.evt_tx_hash AS tx_hash,
        NULL::integer[] AS trace_address,
        t.evt_index
    FROM
        balancer_v2."Vault_evt_Swap" t
    LEFT JOIN balancer_v2.view_pools_fees s ON s.contract_address = SUBSTRING(t."poolId" FROM 0 FOR 21)
        AND s.evt_block_time = (
            SELECT MAX(evt_block_time)
            FROM balancer_v2.view_pools_fees
            WHERE
                evt_block_time <= t.evt_block_time
                AND contract_address = SUBSTRING(t."poolId" FROM 0 FOR 21)
        )
) dexs
INNER JOIN ethereum.transactions tx ON dexs.tx_hash = tx.hash
    AND tx.block_time >= '2022-04-20'
LEFT JOIN erc20.tokens erc20a ON erc20a.contract_address = dexs.token_a_address
LEFT JOIN erc20.tokens erc20b ON erc20b.contract_address = dexs.token_b_address
LEFT JOIN prices.usd pa ON pa.minute = DATE_TRUNC('minute', dexs.block_time)
    AND pa.contract_address = dexs.token_a_address
    AND pa.minute >= '2022-04-20'
LEFT JOIN prices.usd pb ON pb.minute = DATE_TRUNC('minute', dexs.block_time)
    AND pb.contract_address = dexs.token_b_address
    AND pb.minute >= '2022-04-20'
WHERE dexs.block_time >= '2022-04-20'
 ```
 
 Here is the new Dune v2 spell which excludes the new dexs `WHERE` filter for testing purposes:
 
 ```sql
WITH stuff AS (
    SELECT *
    FROM balancer_v2_ethereum.WeightedPool_evt_SwapFeePercentageChanged
    UNION ALL
    SELECT *
    FROM balancer_v2_ethereum.StablePool_evt_SwapFeePercentageChanged
    UNION ALL
    SELECT *
    FROM balancer_v2_ethereum.MetaStablePool_evt_SwapFeePercentageChanged
    UNION ALL
    SELECT *
    FROM balancer_v2_ethereum.LiquidityBootstrappingPool_evt_SwapFeePercentageChanged
    UNION ALL
    SELECT *
    FROM balancer_v2_ethereum.InvestmentPool_evt_SwapFeePercentageChanged
    UNION ALL
    SELECT *
    FROM balancer_v2_ethereum.AaveLinearPool_evt_SwapFeePercentageChanged
    UNION ALL
    SELECT *
    FROM balancer_v2_ethereum.StablePhantomPool_evt_SwapFeePercentageChanged
),
swap_fees AS (
    SELECT
        swap.evt_block_number,
        swap.evt_tx_hash,
        swap.evt_index,
        SUBSTRING(swap. `poolId`, 0, 42) AS contract_address,
    swap.evt_block_time,
    MAX(fees.evt_block_time) AS max_fee_evt_block_time
FROM
    balancer_v2_ethereum.Vault_evt_Swap swap
    LEFT JOIN stuff fees ON fees.contract_address = SUBSTRING(swap. `poolId`, 0, 42)
        AND fees.evt_block_time <= swap.evt_block_time
GROUP BY 1, 2, 3, 4, 5
),
dexs AS (
    SELECT
        swap.evt_block_time AS block_time,
        NULL AS taker,
        NULL AS maker,
        swap. `amountOut` AS token_bought_amount_raw,
        swap. `amountIn` AS token_sold_amount_raw,
        NULL AS amount_usd,
        swap. `tokenOut` AS token_bought_address,
        swap. `tokenIn` AS token_sold_address,
        swap. `poolId` AS project_contract_address,
        pools_fees. `swapFeePercentage` / POWER(10, 18) AS swap_fee,
        swap.evt_tx_hash AS tx_hash,
        NULL AS trace_address,
        swap.evt_index
    FROM swap_fees
    INNER JOIN balancer_v2_ethereum.Vault_evt_Swap swap ON swap.evt_block_number = swap_fees.evt_block_number
        AND swap.evt_tx_hash = swap_fees.evt_tx_hash
        AND swap.evt_index = swap_fees.evt_index
    LEFT JOIN stuff pools_fees ON pools_fees.contract_address = swap_fees.contract_address
        AND pools_fees.evt_block_time = swap_fees.max_fee_evt_block_time
)
SELECT
    COUNT(*)
FROM
    dexs
INNER JOIN ethereum.transactions tx ON tx.hash = dexs.tx_hash
    AND tx.block_time >= '2022-04-20'
LEFT JOIN tokens.erc20 erc20a ON erc20a.contract_address = dexs.token_bought_address
    AND erc20a.blockchain = 'ethereum'
LEFT JOIN tokens.erc20 erc20b ON erc20b.contract_address = dexs.token_sold_address
    AND erc20b.blockchain = 'ethereum'
LEFT JOIN prices.usd p_bought ON p_bought.minute = DATE_TRUNC('minute', dexs.block_time)
    AND p_bought.contract_address = dexs.token_bought_address
    AND p_bought.blockchain = 'ethereum'
    AND p_bought.minute >= '2022-04-20'
LEFT JOIN prices.usd p_sold ON p_sold.minute = DATE_TRUNC('minute', dexs.block_time)
    AND p_sold.contract_address = dexs.token_sold_address
    AND p_sold.blockchain = 'ethereum'
    AND p_sold.minute >= '2022-04-20'
``` 