### PR TITLE
 Migrate `balancer_vebal_balances` abstraction  

### DIFF
--- a/models/balancer/ethereum/balancer_ethereum_schema.yml
+++ b/models/balancer/ethereum/balancer_ethereum_schema.yml
@@ -86,7 +86,7 @@ models:
     meta:
       blockchain: ethereum
       project: balancer_v2
-      contributors: victorstefenon
+      contributors: stefenon
     config:
       tags: ['ethereum', 'bpt', 'prices']
     description: >
@@ -106,3 +106,23 @@ models:
       - &median_price
         name: median_price
         description: 'BPT median price'
+  - name: balancer_ethereum_vebal_balances_day
+    meta:
+      blockchain: ethereum
+      project: balancer
+      contibutors: markusbkoch, mendesfabio, stefenon
+    config:
+      tags: ['balancer', 'ethereum', 'vebal', 'day', 'markusbkoch', 'mendesfabio']
+    description: >
+        Daily balances of veBAL per wallet
+        Depends on veBAL_call_create_lock, veBAL_evt_Deposit and veBAL_evt_Withdraw
+    columns:
+      - *day
+      - name: wallet_address
+        description: "Address of the wallet holding the veBAL"
+      - name: bpt_balance
+        description: "Amount of BPT held in the veBAL lock"
+      - name: vebal_balance
+        description: "Amount of veBAL"
+      - name: lock_time
+        description: "Amount of time the BPT was locked for at the last time the lock was updated"

--- a/models/balancer/ethereum/balancer_ethereum_sources.yml
+++ b/models/balancer/ethereum/balancer_ethereum_sources.yml
@@ -1,9 +1,52 @@
 version: 2
 
 sources:
+  - name: balancer_ethereum
+    description: >
+      Decoded tables related to Balancer, an automated portfolio manager and trading platform, on Ethereum.
+    tables:
+      - name: veBAL_call_create_lock
+        loaded_at_field: call_block_time
+        description: "Function to create a veBAL lock"
+        columns:
+          - name: _unlock_time
+            description: "Epoch time when tokens unlock; this is the user's request, but the actual unlock time will be rounded down to a Thursday"
+          - name: _value
+            description: "Amount to deposit"
+      - name: veBAL_evt_Deposit
+        loaded_at_field: evt_block_time
+        description: "Emitted when user deposits tokens in their lock or extends its unlock time"
+        columns:
+          - name: locktime
+            description: "Epoch time when tokens unlock"
+          - name: provider
+            description: "The wallet address of the lock's owner"
+          - name: ts
+            description: "Block timestamp"
+          - name: type
+            tests:
+              - accepted_values:
+                  values: [0, 1, 2, 3]
+            description: >
+              DEPOSIT_FOR_TYPE: 0
+              CREATE_LOCK_TYPE: 1
+              INCREASE_LOCK_AMOUNT: 2
+              INCREASE_UNLOCK_TIME: 3
+          - name: value
+            description: "Amount of base tokens added to the lock"
+      - name: veBAL_evt_Withdraw
+        loaded_at_field: evt_block_time
+        description: "Emitted when user withdraws tokens from their lock"
+        columns:
+          - name: provider
+            description: "The wallet address of the lock's owner"
+          - name: value
+            description: "Amount of base tokens withdrawn from the lock"
+          - name: ts
+            description: "Block timestamp"
   - name: balancer_v2_ethereum
     description: >
-      Decoded tables related to Balancer v2, an automated portfolio manager and trading platform.
+      Decoded tables related to Balancer v2, an automated portfolio manager and trading platform, on Ethereum.
     tables:
       - name: Vault_evt_PoolRegistered
         description: >
@@ -30,30 +73,6 @@ sources:
             description: 'Unique encoded identifier that refers to each pool'
           - name: specialization
             description: 'Pool specialization'
-
-  - name: balancer_v1_ethereum
-    description: >
-      Decoded tables related to Balancer V1, an automated portfolio manager and trading platform, on Ethereum.
-    tables:
-      - name: BFactory_evt_LOG_NEW_POOL
-        description: >
-          Decoded table related to the Balancer BFactory contract.
-        loaded_at_field: evt_block_time
-        columns:
-          - name: contract_address
-            description: 'Balancer v1 BFactory contract address'
-          - *evt_tx_hash
-          - *evt_index
-          - *evt_block_time
-          - *evt_block_number
-          - name: caller
-            description: 'Caller address that created the Balancer pool'
-          - name: pool
-            description: 'Balancer pool contract address'
-  - name: balancer_v2_ethereum
-    description: >
-      Decoded tables related to Balancer V2, an automated portfolio manager and trading platform, on Ethereum.
-    tables:
       - name: Vault_evt_Swap
         description: >
           Decoded table related to the the contracts emitted by swaps in Balancer V2 pools.
@@ -79,3 +98,22 @@ sources:
             description: 'Raw amount of the token provided to the pool'
           - name: amountOut
             description: 'Raw amount of the token bought from the pool'
+  - name: balancer_v1_ethereum
+    description: >
+      Decoded tables related to Balancer V1, an automated portfolio manager and trading platform, on Ethereum.
+    tables:
+      - name: BFactory_evt_LOG_NEW_POOL
+        description: >
+          Decoded table related to the Balancer BFactory contract.
+        loaded_at_field: evt_block_time
+        columns:
+          - name: contract_address
+            description: 'Balancer v1 BFactory contract address'
+          - *evt_tx_hash
+          - *evt_index
+          - *evt_block_time
+          - *evt_block_number
+          - name: caller
+            description: 'Caller address that created the Balancer pool'
+          - name: pool
+            description: 'Balancer pool contract address'

--- a/models/balancer/ethereum/balancer_ethereum_sources.yml
+++ b/models/balancer/ethereum/balancer_ethereum_sources.yml
@@ -44,17 +44,17 @@ sources:
             description: "Amount of base tokens withdrawn from the lock"
           - name: ts
             description: "Block timestamp"
-  - name: balancer_v2_ethereum
+  - name: balancer_v1_ethereum
     description: >
-      Decoded tables related to Balancer v2, an automated portfolio manager and trading platform, on Ethereum.
+      Decoded tables related to Balancer V1, an automated portfolio manager and trading platform, on Ethereum.
     tables:
-      - name: Vault_evt_PoolRegistered
+      - name: BFactory_evt_LOG_NEW_POOL
         description: >
-          Decoded table of registered pools on the Balancer Vault contract.
+          Decoded table related to the Balancer BFactory contract.
         loaded_at_field: evt_block_time
         columns:
           - name: contract_address
-            description: 'Balancer v2 Vault contract address'
+            description: 'Balancer v1 BFactory contract address'
           - &evt_tx_hash
             name: evt_tx_hash
             description: 'Primary key of the transaction'
@@ -67,6 +67,25 @@ sources:
           - &evt_block_number
             name: evt_block_number
             description: 'Block number which processed the unique transaction hash'
+          - name: caller
+            description: 'Caller address that created the Balancer pool'
+          - name: pool
+            description: 'Balancer pool contract address'
+  - name: balancer_v2_ethereum
+    description: >
+      Decoded tables related to Balancer v2, an automated portfolio manager and trading platform, on Ethereum.
+    tables:
+      - name: Vault_evt_PoolRegistered
+        description: >
+          Decoded table of registered pools on the Balancer Vault contract.
+        loaded_at_field: evt_block_time
+        columns:
+          - name: contract_address
+            description: 'Balancer v2 Vault contract address'
+          - *evt_tx_hash
+          - *evt_index
+          - *evt_block_time
+          - *evt_block_number
           - name: poolAddress
             description: 'Ethereum address for the liquidity pool used in transaction'
           - name: poolId
@@ -98,22 +117,3 @@ sources:
             description: 'Raw amount of the token provided to the pool'
           - name: amountOut
             description: 'Raw amount of the token bought from the pool'
-  - name: balancer_v1_ethereum
-    description: >
-      Decoded tables related to Balancer V1, an automated portfolio manager and trading platform, on Ethereum.
-    tables:
-      - name: BFactory_evt_LOG_NEW_POOL
-        description: >
-          Decoded table related to the Balancer BFactory contract.
-        loaded_at_field: evt_block_time
-        columns:
-          - name: contract_address
-            description: 'Balancer v1 BFactory contract address'
-          - *evt_tx_hash
-          - *evt_index
-          - *evt_block_time
-          - *evt_block_number
-          - name: caller
-            description: 'Caller address that created the Balancer pool'
-          - name: pool
-            description: 'Balancer pool contract address'

--- a/models/balancer/ethereum/balancer_ethereum_vebal_balances_day.sql
+++ b/models/balancer/ethereum/balancer_ethereum_vebal_balances_day.sql
@@ -1,0 +1,144 @@
+{{
+    config(
+        schema = 'balancer_ethereum',
+        alias='vebal_balances_day',
+        post_hook='{{ expose_spells(\'["ethereum"]\',
+                                    "project",
+                                    "balancer",
+                                    \'["markusbkoch", "mendesfabio", "stefenon"]\') }}'
+    )
+}}
+
+WITH base_locks AS (
+        SELECT d.provider, ts AS locked_at, locktime AS unlocked_at, ts AS updated_at
+        FROM {{ source('balancer_ethereum', 'veBAL_call_create_lock') }} l  
+        JOIN {{ source('balancer_ethereum', 'veBAL_evt_Deposit') }} d
+        ON d.evt_tx_hash = l.call_tx_hash
+        
+        UNION ALL
+        
+        SELECT provider, null::numeric AS locked_at, locktime AS unlocked_at, ts AS updated_at
+        FROM {{ source('balancer_ethereum', 'veBAL_evt_Deposit') }}
+        WHERE value = 0
+    ),
+    
+    decorated_locks AS (
+        SELECT
+          provider, unlocked_at, updated_at, FIRST_VALUE(locked_at) OVER (PARTITION BY provider, locked_partition ORDER BY updated_at) AS locked_at
+        FROM (
+          SELECT
+            *,
+            SUM(CASE WHEN locked_at IS NULL THEN 0 ELSE 1 END) OVER (PARTITION BY provider ORDER BY updated_at) AS locked_partition
+          FROM base_locks
+        ) AS foo
+    ),
+    
+    locks_info AS (
+        SELECT *, unlocked_at - locked_at AS lock_period
+        FROM decorated_locks
+    ),
+
+    deposits AS (
+        SELECT
+            provider,
+            date_trunc('day', evt_block_time) AS day,
+            SUM(value/1e18) AS delta_bpt
+        FROM {{ source('balancer_ethereum', 'veBAL_evt_Deposit') }}
+        GROUP BY 1, 2
+    ),
+    
+    withdrawals AS (
+        SELECT 
+            provider,
+            date_trunc('day', evt_block_time) AS day,
+            -SUM(value/1e18) AS delta_bpt
+        FROM {{ source('balancer_ethereum', 'veBAL_evt_Withdraw') }}
+        GROUP BY 1, 2
+    ),
+    
+    bpt_locked_balance AS (
+        SELECT day, provider, SUM(delta_bpt) AS bpt_balance
+        FROM (
+            SELECT * FROM deposits
+            UNION ALL
+            SELECT * FROM withdrawals
+        ) union_all
+        GROUP BY 1, 2
+    ),
+    
+    calendar AS (
+        SELECT 
+          explode(sequence(MIN(day), CURRENT_DATE, interval 1 day)) AS day
+        FROM bpt_locked_balance
+    ),
+    
+    cumulative_balances AS (
+        SELECT
+            day,
+            provider,
+            LEAD(DAY, 1, NOW()) OVER (
+                PARTITION BY provider
+                ORDER BY day
+            ) AS day_of_next_change,
+            SUM(bpt_balance) OVER (
+                PARTITION BY provider
+                ORDER BY DAY
+                ROWS BETWEEN
+                UNBOUNDED PRECEDING AND
+                CURRENT ROW
+            ) AS bpt_balance
+        FROM bpt_locked_balance
+    ),
+    
+    running_balances AS (
+        SELECT
+            c.day,
+            provider,
+            bpt_balance
+        FROM calendar c
+        LEFT JOIN cumulative_balances b
+        ON b.day <= c.day
+        AND c.day < b.day_of_next_change
+    ),
+    
+    double_counting AS (
+        SELECT
+            day,
+            b.provider as wallet_address,
+            bpt_balance,
+            updated_at,
+            lock_period as lock_time,
+            GREATEST(
+                COALESCE(
+                    bpt_balance *
+                    (lock_period / (365*86400)) *
+                    ((unlocked_at - (unix_timestamp(b.day)+86400)) / lock_period)
+                    , 0),
+                0
+             ) AS vebal_balance
+        FROM running_balances b
+        LEFT JOIN locks_info l
+        ON l.provider = b.provider
+        AND l.updated_at <= unix_timestamp(b.day) + 86400
+    ),
+    
+    max_updated_at AS (
+        SELECT 
+            day,
+            wallet_address,
+            max(updated_at) AS updated_at
+        FROM double_counting
+        GROUP BY 1,2
+    )
+    
+SELECT 
+    a.day,
+    a.wallet_address,
+    a.bpt_balance,
+    a.vebal_balance,
+    a.lock_time
+FROM double_counting a
+INNER JOIN max_updated_at b
+ON a.day = b.day
+AND a.wallet_address = b.wallet_address
+AND a.updated_at = b.updated_at


### PR DESCRIPTION
Brief comments on the purpose of your changes:

Migrate `balancer_vebal_balances` abstraction to Dune V2 spellbook.

**For Dune Engine V2**

I've checked that:

### General checks:
* [x] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [x] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [x] if adding a new model, I added a test
* [x] the filename is unique and ends with .sql
* [x] each sql file is a select statement and has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [x] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [x] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
