### PR TITLE
Fix Balancer Post Hooks

### DIFF
--- a/models/balancer/arbitrum/balancer_v2_arbitrum_bpt_prices.sql
+++ b/models/balancer/arbitrum/balancer_v2_arbitrum_bpt_prices.sql
@@ -4,7 +4,7 @@
         alias='bpt_prices',
         post_hook='{{ expose_spells_hide_trino(\'["arbitrum"]\',
                                     "project",
-                                    "balancer",
+                                    "balancer_v2",
                                     \'["victorstefenon"]\') }}'
     )
 }}

--- a/models/balancer/arbitrum/balancer_v2_arbitrum_pools_tokens_weights.sql
+++ b/models/balancer/arbitrum/balancer_v2_arbitrum_pools_tokens_weights.sql
@@ -8,7 +8,7 @@
         unique_key = ['pool_id', 'token_address'],
         post_hook='{{ expose_spells(\'["arbitrum"]\',
                                     "project",
-                                    "balancer",
+                                    "balancer_v2",
                                     \'["metacrypto", "jacektrocinski"]\') }}'
     )
 }}

--- a/models/balancer/ethereum/balancer_v1_ethereum_pools_tokens_weights.sql
+++ b/models/balancer/ethereum/balancer_v1_ethereum_pools_tokens_weights.sql
@@ -8,7 +8,7 @@
         unique_key = ['pool_id', 'token_address'],
         post_hook='{{ expose_spells(\'["ethereum"]\',
                                     "project",
-                                    "balancer",
+                                    "balancer_v1",
                                     \'["metacrypto", "jacektrocinski"]\') }}'
     ) 
 }}

--- a/models/balancer/ethereum/balancer_v2_ethereum_bpt_prices.sql
+++ b/models/balancer/ethereum/balancer_v2_ethereum_bpt_prices.sql
@@ -4,7 +4,7 @@
         alias='bpt_prices',
         post_hook='{{ expose_spells_hide_trino(\'["ethereum"]\',
                                     "project",
-                                    "balancer",
+                                    "balancer_v2",
                                     \'["victorstefenon"]\') }}'
     )
 }}

--- a/models/balancer/ethereum/balancer_v2_ethereum_pools_tokens_weights.sql
+++ b/models/balancer/ethereum/balancer_v2_ethereum_pools_tokens_weights.sql
@@ -8,7 +8,7 @@
         unique_key = ['pool_id', 'token_address'],
         post_hook='{{ expose_spells(\'["ethereum"]\',
                                     "project",
-                                    "balancer",
+                                    "balancer_v2",
                                     \'["metacrypto", "jacektrocinski"]\') }}'
     )
 }}

--- a/models/balancer/optimism/balancer_v2_optimism_bpt_prices.sql
+++ b/models/balancer/optimism/balancer_v2_optimism_bpt_prices.sql
@@ -4,7 +4,7 @@
         alias='bpt_prices',
         post_hook='{{ expose_spells_hide_trino(\'["optimism"]\',
                                     "project",
-                                    "balancer",
+                                    "balancer_v2",
                                     \'["victorstefenon"]\') }}'
     )
 }}

--- a/models/balancer/optimism/balancer_v2_optimism_pools_tokens_weights.sql
+++ b/models/balancer/optimism/balancer_v2_optimism_pools_tokens_weights.sql
@@ -8,7 +8,7 @@
         unique_key = ['pool_id', 'token_address'],
         post_hook='{{ expose_spells(\'["optimism"]\',
                                     "project",
-                                    "balancer",
+                                    "balancer_v2",
                                     \'["metacrypto", "jacektrocinski"]\') }}'
     )
 }}

--- a/models/balancer/polygon/balancer_v2_polygon_bpt_prices.sql
+++ b/models/balancer/polygon/balancer_v2_polygon_bpt_prices.sql
@@ -4,7 +4,7 @@
         alias='bpt_prices',
         post_hook='{{ expose_spells_hide_trino(\'["polygon"]\',
                                     "project",
-                                    "balancer",
+                                    "balancer_v2",
                                     \'["victorstefenon"]\') }}'
     )
 }}

--- a/models/balancer/polygon/balancer_v2_polygon_pools_tokens_weights.sql
+++ b/models/balancer/polygon/balancer_v2_polygon_pools_tokens_weights.sql
@@ -8,7 +8,7 @@
         unique_key = ['pool_id', 'token_address'],
         post_hook='{{ expose_spells(\'["polygon"]\',
                                     "project",
-                                    "balancer",
+                                    "balancer_v2",
                                     \'["metacrypto", "jacektrocinski"]\') }}'
     )
 }}


### PR DESCRIPTION
Brief comments on the purpose of your changes:

 - Fixed the post hooks for Balancer queries so that there is distinction between Balancer v1 and v2 queries.

**For Dune Engine V2**

I've checked that:

### General checks:
* [x] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [x] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [x] if adding a new model, I added a test
* [x] the filename is unique and ends with .sql
* [x] each sql file is a select statement and has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
* [x] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [x] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] ~~`coin_id` represents the ID of the coin on coinpaprika.com~~
* [ ] ~~all the coins are active on coinpaprika.com (please remove inactive ones)~~

### Join logic:
* [ ] ~~if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible~~

### Incremental logic:
* [ ] ~~I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables~~
  * [ ] ~~where block_time >= date_trunc("day", now() - interval '1 week')~~
* [ ] ~~if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')~~
* [ ] ~~if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')~~
